### PR TITLE
Improve Bash compatibility and logging in OpenShift SOS plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+install:
+	chmod +x ./sos.sh
+	sudo cp ./sos.sh /usr/local/bin/kubectl-sos
+	@echo "Installed successfuly"
+	@echo "Run \"oc sos\" to execute"
+


### PR DESCRIPTION
- Replaced hardcoded ANSI escape sequences with tput for better portability across terminals.
- Improved namespace retrieval using oc config view.
- Modified mktemp usage to remove --suffix, ensuring compatibility across different systems.
- Added a conditional check for Bash 4.1+ to use BASH_XTRACEFD.
- Provided fallback for older Bash versions (default macOS Bash) using exec 2>> log file.
- These changes improve cross-platform compatibility and ensure better debugging/logging behavior.